### PR TITLE
Fixes anomalies spawning directly in the SME core and on shuttles

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -97,10 +97,8 @@ SUBSYSTEM_DEF(events)
 	var/list/safe_areas = list(
 	/area/ai_monitored/turret_protected/ai,
 	/area/ai_monitored/turret_protected/ai_upload,
-	/area/engine,
 	/area/solar,
 	/area/holodeck,
-	/area/shuttle
 	)
 
 	//These are needed because /area/engine has to be removed from the list, but we still want these areas to get fucked up.


### PR DESCRIPTION
:cl: Ordo
:bugfix: Prevents anomalies from spawning in areas they shouldn't.
/:cl

See Issue #33611